### PR TITLE
chore: Removed the invalid package-name parameter

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,4 +23,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
-          package-name: '@svmukhin/edible-css'


### PR DESCRIPTION
Closes #5 

This pull request makes a minor update to the release workflow configuration by removing the `package-name` field from the release job. No other significant changes are included.