### PR TITLE
added CHANGELOG.md to the ignore list in .markdownlint-cli2.yaml

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -3,8 +3,7 @@
 ---
 gitignore: true
 ignores:
-  - .github/agents
-  - .specify/templates
+  - CHANGELOG.md
 
 config:
   MD013:


### PR DESCRIPTION
Closes #9 

This pull request makes a minor update to the `.markdownlint-cli2.yaml` configuration file by excluding `CHANGELOG.md` from linting. This helps avoid unnecessary lint errors in the changelog file.