### PR TITLE
fix(#27): added margin-inline-end spacing between buttons

### DIFF
--- a/src/forms.css
+++ b/src/forms.css
@@ -158,6 +158,7 @@ input[type="reset"] {
   text-decoration: none;
   transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   margin-bottom: var(--space-sm);
+  margin-inline-end: var(--space-sm);
 }
 
 button:hover,


### PR DESCRIPTION
Closes #27 

**Problem**

Multiple buttons rendered side by side had no visible gap between them, causing them to visually merge into a single element and reducing usability.

The gap previously visible in example files was caused by browser whitespace handling between `inline-block` elements — an unreliable artifact dependent on HTML formatting, not CSS.

**Solution**

Added `margin-inline-end: var(--space-sm)` to the button rule in forms.css. This provides explicit, predictable spacing after each button regardless of how tags are written in the markup.

**Changes**

- forms.css — added `margin-inline-end: var(--space-sm)` to `button, input[type="submit"], input[type="button"], input[type="reset"]`