### PR TITLE
fix(#31): replace the transparent value with a solid color token

### DIFF
--- a/src/dark-mode.css
+++ b/src/dark-mode.css
@@ -30,7 +30,7 @@
   input:not([type="checkbox"]):not([type="radio"]),
   textarea,
   select {
-    background: rgba(255, 255, 255, 0.05);
+    background: var(--bg-secondary);
     border-color: var(--border);
   }
 


### PR DESCRIPTION
Closes #31 

Replace the transparent value with a solid color token:

```css
@media (prefers-color-scheme: dark) {
  input:not([type="checkbox"]):not([type="radio"]),
  textarea,
  select {
    background: var(--bg-secondary);
    border-color: var(--border);
  }
}
```

Using an opaque `--bg-secondary` (`#161b22`) ensures the native dropdown inherits a dark background regardless of how the OS composites it.

### Additional Notes

- `color-scheme: dark` on `select` was also tested but did not reliably fix the issue across browsers.
- Setting `background-color` on `option` elements has no effect — native dropdowns ignore it on most platforms.
- The solid token approach is the most cross-browser compatible solution.