### PR TITLE
feat(#34): added a text color change to the hover state

### DIFF
--- a/src/semantic.css
+++ b/src/semantic.css
@@ -29,11 +29,12 @@ nav a {
   text-decoration: none;
   color: var(--text-primary);
   border-radius: 4px;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s, color 0.2s;
 }
 
 nav a:hover {
   background-color: var(--bg-tertiary);
+  color: var(--button-bg-hover);
 }
 
 nav a:focus {


### PR DESCRIPTION
Closes #34 

Added a text color change to the hover state to make the interaction clearly visible:

```css
nav a:hover {
  background-color: var(--bg-tertiary);
  color: var(--button-bg-hover);
}
```

The `--button-bg-hover` token (`#0860ca` / `#388bfd` in dark mode) provides sufficient contrast and is already used for interactive element emphasis, making it a semantically appropriate choice here.

Also extended the `transition` property to include `color`:

```css
transition: background-color 0.2s, color 0.2s;
```